### PR TITLE
레디스 대기열 구현

### DIFF
--- a/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/application/QueueFacade.java
+++ b/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/application/QueueFacade.java
@@ -1,83 +1,41 @@
 package com.hhplus.concert_ticketing.application;
 
-import com.hhplus.concert_ticketing.domain.queue.*;
-import com.hhplus.concert_ticketing.domain.user.UserEntity;
-import com.hhplus.concert_ticketing.domain.user.UserService;
+import com.hhplus.concert_ticketing.domain.queue.QueueService;
 import com.hhplus.concert_ticketing.presentation.queue.TokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
-
 @Service
 @RequiredArgsConstructor
 public class QueueFacade {
 
     private static final Logger logger = LoggerFactory.getLogger(QueueFacade.class);
-
     private final QueueService queueService;
-    private final UserService userService;
-    private final QueueRepository queueRepository;
 
-    // 토큰 생성
+    // 토큰 생성 및 대기열에 추가
     public String requestToken(Long userId) {
-
-        // 사용자 조회
-        UserEntity user;
-        try {
-            user = userService.getUserInfo(userId);
-        } catch (Exception e) {
-            logger.error("사용자 ID {} 조회 실패: {}", userId, e.getMessage());
-            throw e;
-        }
-
-        // 토큰 생성
-        String token;
-        try {
-            token = queueService.generateToken(userId).getToken();
-        } catch (Exception e) {
-            logger.error("사용자 ID {}에 대한 토큰 생성 실패: {}", userId, e.getMessage());
-            throw e;
-        }
-
+        String token = java.util.UUID.randomUUID().toString();  // 토큰 생성
+        queueService.addTokenToWaitingList(token);
+        logger.info("사용자 ID {}에 대한 토큰 발급 완료: {}", userId, token);
         return token;
     }
 
     // 토큰 상태 확인
     public TokenResponse checkTokenStatus(String token) {
-
-        TokenEntity tokenEntity;
-        try {
-            tokenEntity = queueService.checkToken(token);
-        } catch (Exception e) {
-            logger.error("토큰 조회 실패: {}", token, e.getMessage());
-            throw e;
-        }
-
-        TokenStatus status = tokenEntity.getStatus();
-
-        if (status == TokenStatus.ACTIVE) {
-            return QueueMapper.toResponseDTO(tokenEntity, "200", "예약 페이지로 이동합니다.", 0);
+        if (queueService.checkTokenValidity(token)) {
+            // 토큰이 활성화 상태일 경우
+            return new TokenResponse("200", "예약 페이지로 이동합니다.", token, 0);
         } else {
-            int waitingCount = queueService.getWaitingCount(token) + 30;    // 최대 active 인원은 30명
-            return QueueMapper.toResponseDTO(tokenEntity, "100", "계속 대기합니다.", waitingCount);
-        }
-    }
-
-    // 토큰 상태 관리
-    public void manageTokens() {
-        Timestamp now = new Timestamp(System.currentTimeMillis());
-
-        try {
-            // 만료된 토큰 상태를 EXPIRED로 변경
-            queueService.expireTokens();
-            // 활성화 토큰이 30개 미만이면, 대기 중인 토큰을 활성화로 변경
-            queueService.activateTokens();
-        } catch (Exception e) {
-            logger.error("토큰 상태 관리 실패: {}", e.getMessage());
-            throw e;
+            // 토큰이 대기열에 있을 경우
+            long tokenRank = queueService.getTokenRank(token);
+            if (tokenRank == -1) {
+                // 대기열에 없는 토큰
+                return new TokenResponse("400", "토큰이 유효하지 않습니다.", token, 0);
+            }
+            long waitingCount = queueService.getWaitingCount();
+            return new TokenResponse("100", "계속 대기합니다.", token, (int) (waitingCount - tokenRank));
         }
     }
 }

--- a/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/config/RedisCacheConfig.java
+++ b/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/config/RedisCacheConfig.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 @EnableCaching
 public class RedisCacheConfig {
 
+    //
     @Bean
     public CacheManager userCacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()

--- a/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/presentation/queue/QueueController.java
+++ b/3w_ticketing/src/main/java/com/hhplus/concert_ticketing/presentation/queue/QueueController.java
@@ -1,7 +1,6 @@
 package com.hhplus.concert_ticketing.presentation.queue;
 
 import com.hhplus.concert_ticketing.application.QueueFacade;
-import com.hhplus.concert_ticketing.domain.queue.QueueMapper;
 import com.hhplus.concert_ticketing.presentation.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,12 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @RestController
 @RequestMapping("/queue")
@@ -35,26 +31,18 @@ public class QueueController {
                     @ApiResponse(responseCode = "200", description = "성공적으로 토큰을 발급했습니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))
                     ),
-                    @ApiResponse(responseCode = "401", description = "접근이 유효하지 않습니다.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
-                    ),
                     @ApiResponse(responseCode = "500", description = "서버 오류로 인해 토큰 발급에 실패했습니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
                     )
             }
     )
-    public ResponseEntity<?> issueToken(@RequestBody TokenRequest request) {
+    public ResponseEntity<Object> issueToken(@RequestBody TokenRequest request) {
         try {
             String token = queueFacade.requestToken(request.getUserId());
-            TokenDto tokenDto = new TokenDto(token, 1, "2024-07-04T12:00:00", 0);
-            TokenResponse response = new TokenResponse("200", "Success", tokenDto);
+            TokenResponse response = new TokenResponse("200", "토큰이 발급되었습니다.", token, 0);
             return ResponseEntity.ok(response);
-        } catch (RuntimeException e) {
-            logger.error("토큰 발급 중 오류 발생. 사용자 ID: {}, 오류 메시지: {}", request.getUserId(), e.getMessage());
-            ErrorResponse errorResponse = new ErrorResponse("401", "접근이 유효하지 않습니다.");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
         } catch (Exception e) {
-            logger.error("서버 오류로 인해 토큰 발급에 실패했습니다. 사용자 ID: {}, 오류 메시지: {}", request.getUserId(), e.getMessage());
+            logger.error("토큰 발급 중 오류 발생. 사용자 ID: {}, 오류 메시지: {}", request.getUserId(), e.getMessage());
             ErrorResponse errorResponse = new ErrorResponse("500", "서버에서 오류가 발생했습니다.");
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
@@ -68,17 +56,8 @@ public class QueueController {
                     @ApiResponse(responseCode = "100", description = "계속 대기 합니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))
                     ),
-                    @ApiResponse(responseCode = "303", description = "토큰 상태가 'ACTIVE'인 경우 리다이렉션",
-                            headers = {
-                                    @io.swagger.v3.oas.annotations.headers.Header(
-                                            name = HttpHeaders.LOCATION,
-                                            description = "리다이렉션할 예약 페이지의 URL",
-                                            schema = @Schema(type = "string", example = "/reservation-page")
-                                    )
-                            }
-                    ),
-                    @ApiResponse(responseCode = "401", description = "접근이 유효하지 않습니다.",
-                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
+                    @ApiResponse(responseCode = "200", description = "토큰 상태가 'ACTIVE'인 경우",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))
                     ),
                     @ApiResponse(responseCode = "400", description = "잘못된 토큰 상태입니다.",
                             content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))
@@ -88,28 +67,24 @@ public class QueueController {
                     )
             }
     )
-    public ResponseEntity<?> checkQueue(@RequestParam String token) {
+    public ResponseEntity<Object> checkQueue(@RequestParam String token) {
         try {
             TokenResponse response = queueFacade.checkTokenStatus(token);
 
-            if (response.getResult().equals("200")) {
-                HttpHeaders headers = new HttpHeaders();
-                headers.setLocation(URI.create("/reservation-page"));
-                logger.info("토큰 상태가 'ACTIVE'입니다. 리다이렉션: /reservation-page");
-                return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
-            } else if (response.getResult().equals("100")) {
-                logger.info("계속 대기 상태입니다. 토큰: {}", token);
+            if ("200".equals(response.getResult())) {
+                return ResponseEntity.ok(response);
+            } else if ("100".equals(response.getResult())) {
                 return ResponseEntity.status(HttpStatus.CONTINUE).body(response);
             } else {
                 logger.warn("잘못된 토큰 상태입니다. 상태: {}, 메시지: {}", response.getResult(), response.getMessage());
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(QueueMapper.toErrorResponseDTO(response.getResult(), response.getMessage()));
+                ErrorResponse errorResponse = new ErrorResponse("400", response.getMessage());
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
             }
-        } catch (IllegalArgumentException e) {
-            logger.error("잘못된 요청으로 대기열 체크 실패. 토큰: {}, 오류 메시지: {}", token, e.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(QueueMapper.toErrorResponseDTO("400", e.getMessage()));
         } catch (Exception e) {
             logger.error("서버 오류로 대기열 체크 실패. 토큰: {}, 오류 메시지: {}", token, e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(QueueMapper.toErrorResponseDTO("500", "서버에서 오류가 발생했습니다."));
+            ErrorResponse errorResponse = new ErrorResponse("500", "서버에서 오류가 발생했습니다.");
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
         }
     }
 }
+

--- a/3w_ticketing/src/test/java/com/hhplus/concert_ticketing/QueueIntegrationTest.java
+++ b/3w_ticketing/src/test/java/com/hhplus/concert_ticketing/QueueIntegrationTest.java
@@ -1,135 +1,61 @@
 package com.hhplus.concert_ticketing;
 
-import com.hhplus.concert_ticketing.application.QueueFacade;
-import com.hhplus.concert_ticketing.presentation.ErrorResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.hhplus.concert_ticketing.presentation.queue.QueueController;
-import com.hhplus.concert_ticketing.presentation.queue.TokenDto;
-import com.hhplus.concert_ticketing.presentation.queue.TokenRequest;
 import com.hhplus.concert_ticketing.presentation.queue.TokenResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import java.util.Objects;
 
-@SpringBootTest
-class QueueIntegrationTest {
+import static org.junit.jupiter.api.Assertions.*;
 
-    @Autowired
-    private QueueController queueController;
-
-    @Autowired
-    private QueueFacade queueFacade;
+@SpringBootTest(classes = ConcertTicketingApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class QueueIntegrationTest {
 
     @Autowired
-    private ObjectMapper objectMapper;
-
-    @BeforeEach
-    void setUp() {
-        objectMapper.registerModule(new JavaTimeModule());
-    }
+    private TestRestTemplate restTemplate;
 
     @Test
-    void issueToken_성공() throws Exception {
-        // given
-        TokenRequest request = new TokenRequest(123L); // userId를 long 타입으로 설정
-        String token = "some-unique-token";
-        TokenDto tokenDto = new TokenDto(token, 1, "2024-07-04T12:00:00", 0);
-        TokenResponse expectedResponse = new TokenResponse("200", "Success", tokenDto);
+    public void testQueueProcessing() throws Exception {
+        // 1. 토큰 발급 요청
+        String requestJson = "{\"userId\": 300}";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> requestEntity = new HttpEntity<>(requestJson, headers);
 
-        when(queueFacade.requestToken(anyLong())).thenReturn(token);
+        ResponseEntity<String> tokenResponse = restTemplate.postForEntity("/queue/issue-token", requestEntity, String.class);
 
-        // when
-        ResponseEntity<?> result = queueController.issueToken(request);
+        // 상태 코드 검증
+        assertEquals(HttpStatus.OK, tokenResponse.getStatusCode(), "토큰 발급 완료");
 
-        // then
-        assertEquals(HttpStatus.OK, result.getStatusCode());
-        assertEquals(objectMapper.writeValueAsString(expectedResponse), result.getBody());
+        // 응답 본문에서 토큰 추출 (단순 문자열 파싱)
+        String token = extractTokenFromResponse(tokenResponse.getBody());
+
+        // 2. 대기 시간 동안 기다림
+        Thread.sleep(60000); // 1분 대기
+
+        // 3. 대기열 상태 체크 요청
+        ResponseEntity<String> checkResponse = restTemplate.getForEntity("/queue/check-queue?token=" + token, String.class);
+
+        // 상태 코드 검증
+        assertEquals(HttpStatus.OK, checkResponse.getStatusCode(), "Active 샹태 확인");
     }
 
-    @Test
-    void issueToken_실패() throws Exception {
-        // given
-        TokenRequest request = new TokenRequest(123L); // userId를 long 타입으로 설정
-
-        when(queueFacade.requestToken(anyLong())).thenThrow(new RuntimeException("접근이 유효하지 않습니다."));
-
-        // when
-        ResponseEntity<?> result = queueController.issueToken(request);
-
-        // then
-        assertEquals(HttpStatus.UNAUTHORIZED, result.getStatusCode());
-        ErrorResponse errorResponse = new ErrorResponse("401", "접근이 유효하지 않습니다.");
-        assertEquals(objectMapper.writeValueAsString(errorResponse), result.getBody());
-    }
-
-    @Test
-    void checkQueue_성공_리다이렉션() throws Exception {
-        // given
-        String token = "valid-token";
-        TokenResponse tokenResponse = new TokenResponse("200", "Success", null);
-
-        when(queueFacade.checkTokenStatus(token)).thenReturn(tokenResponse);
-
-        // when
-        ResponseEntity<?> result = queueController.checkQueue(token);
-
-        // then
-        assertEquals(HttpStatus.SEE_OTHER, result.getStatusCode());
-        assertEquals("/reservation-page", result.getHeaders().getLocation().toString());
-    }
-
-    @Test
-    void checkQueue_성공_대기() throws Exception {
-        // given
-        String token = "waiting-token";
-        TokenResponse tokenResponse = new TokenResponse("100", "Waiting", null);
-
-        when(queueFacade.checkTokenStatus(token)).thenReturn(tokenResponse);
-
-        // when
-        ResponseEntity<?> result = queueController.checkQueue(token);
-
-        // then
-        assertEquals(HttpStatus.CONTINUE, result.getStatusCode());
-        assertEquals(objectMapper.writeValueAsString(tokenResponse), result.getBody());
-    }
-
-    @Test
-    void checkQueue_실패_잘못된_토큰() throws Exception {
-        // given
-        String token = "invalid-token";
-
-        when(queueFacade.checkTokenStatus(token)).thenThrow(new IllegalArgumentException("잘못된 토큰 상태입니다."));
-
-        // when
-        ResponseEntity<?> result = queueController.checkQueue(token);
-
-        // then
-        assertEquals(HttpStatus.BAD_REQUEST, result.getStatusCode());
-        ErrorResponse errorResponse = new ErrorResponse("400", "잘못된 토큰 상태입니다.");
-        assertEquals(objectMapper.writeValueAsString(errorResponse), result.getBody());
-    }
-
-    @Test
-    void checkQueue_실패_서버_오류() throws Exception {
-        // given
-        String token = "some-token";
-
-        when(queueFacade.checkTokenStatus(token)).thenThrow(new RuntimeException("서버에서 오류가 발생했습니다."));
-
-        // when
-        ResponseEntity<?> result = queueController.checkQueue(token);
-
-        // then
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.getStatusCode());
-        ErrorResponse errorResponse = new ErrorResponse("500", "서버에서 오류가 발생했습니다.");
-        assertEquals(objectMapper.writeValueAsString(errorResponse), result.getBody());
+    // 응답 본문에서 토큰을 추출하는 간단한 메서드
+    private String extractTokenFromResponse(String responseBody) {
+        // 간단한 파싱 로직 (JSON 파싱 라이브러리를 사용할 수도 있음)
+        // 예를 들어, {"result":"200", "message":"토큰이 발급되었습니다.", "token":"your-token-value"}
+        if (responseBody == null) {
+            return "";
+        }
+        int startIndex = responseBody.indexOf("token\":\"") + 8;
+        int endIndex = responseBody.indexOf("\"", startIndex);
+        return responseBody.substring(startIndex, endIndex);
     }
 }


### PR DESCRIPTION
**구현 방향**
기존 DB로 대기열을 구현했을 때는 스케쥴러가 1분마다 돌면서 만료된 토큰만큼 토큰을 Active 처리해주는 은행창구 방식이었다.

대용량 트래픽이 들어올 때 유량 제어를 통한 서버 부하 감소라는 장점이 있지만, 몇 만 명이 몰릴 경우 뒷 사람은 앞 사람의 토큰이 만료될 때까지 무한정 대기하게 되어 사용자 경험의 질을 저해할 수 있다.

때문에 이번에는 일정 시간마다 N명을 예약 가능한 상태로 전환해주는 놀이동산 방식을 채택했다.

사용자 플로우는 1분 정도면 예약까지 끝난다고 가정
사용자는 날짜 조회, 좌석 조회, 좌석 예약 API를 사용하고, 각각의 api 소요시간을 측정하여 계산

1. 각 API 호출에 걸리는 시간 계산
- API별 호출 횟수
날짜 조회: 1회
좌석 조회: 2.5회 (예상 평균값)
좌석 예약: 1회

- API별 호출 시간:
날짜 조회: 10ms
좌석 조회: 25ms * 2.5회 = 62.5ms
좌석 예약: 60ms

- 총합: 10ms + 62.5ms + 60ms = 132.5ms

2. TPS (초당 트랜잭션 수) 계산
사용자 수 = 1000𝑚𝑠 / 132.5𝑚𝑠 ≈ 7.55명/초
TPS를 보수적으로 잡아야 하므로, 동시 접속자 수를 7명으로 설정

3. 1분 동안 처리 가능한 사용자 수 계산
사용자 수 = 7명/초 × 60초 = 420명/분

사용자 플로우가 1분 정도 걸리므로 1분에 한 번 최대 420명씩 토큰을 활성화시키는 로직을 구현했다.
``` 
    // 매 1분마다 실행되어 `waiting` 토큰을 `active` 토큰으로 전환하는 메서드
    @Scheduled(fixedRate = 60000)
    public void activateWaitingTokens() {
        // 대기열에서 앞에 있는 420개의 토큰을 가져옴
        Set<String> tokensToActivate = redisTemplate.opsForZSet().range(WAITING_TOKENS_KEY, 0, TOKENS_TO_ACTIVATE_PER_MINUTE - 1);

        if (tokensToActivate != null && !tokensToActivate.isEmpty()) {
            // 가져온 토큰들을 활성화 목록으로 이동하고, TTL 설정
            for (String token : tokensToActivate) {
                redisTemplate.opsForSet().add(ACTIVE_TOKENS_KEY, token);
                redisTemplate.expire(ACTIVE_TOKENS_KEY, TOKEN_TTL_SECONDS, TimeUnit.SECONDS);
                redisTemplate.opsForZSet().remove(WAITING_TOKENS_KEY, token);
            }
        }
    }
```

또한 토큰 만료 시간을 5분으로 설정하여 시간이 되면 대기열에서 바로 삭제되도록 하였으며,
사용자가 예약을 진행하여 더 이상 토큰이 필요없을 때도 바로 삭제되도록 하여 Active Token 대기열의 부하를 조금이라도 줄이려고 했다.


**고려해야할 점**
1. 어떻게 부하테스트를 진행해 볼 것인가
2. 토큰 활성화 주기를 줄일 경우 예약 완료한 고객보다 진행하는 고객 수의 증가 증가 속도가 높아 Active Token 대기열에 부하가 심해질 수 있는데 어떻게 예방할 수 있을까? 


**궁금한 점**
1. 1분 마다 420명을 들여보낸다고 가정했는데, 시간이 너무 길거나 사람이 너무 적은지 궁금합니다.
3. TTL로 토큰을 제어하는 것 외에도 사용자가 토큰이 더 이상 필요하지 않아지면 바로 삭제하는 게 부하를 줄이는 데 도움이 된다고 생각했는데요, 혹시 오히려 삭제가 빈번하게 일어나서 부하가 심해지는 것은 아닌지 우려됩니다.